### PR TITLE
Remove extra semicolon at the end of QML_ELEMENTs

### DIFF
--- a/bookmarkdetails.h
+++ b/bookmarkdetails.h
@@ -5,7 +5,7 @@
 class BookmarkDetails : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(bool, isBookmarked)
     QM_PROPERTY(QList<BookmarkTag *>, tags)
@@ -28,7 +28,7 @@ public:
 class FollowDetails : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(bool, isFollowed)
     QM_PROPERTY(QString, restriction)

--- a/comment.h
+++ b/comment.h
@@ -5,7 +5,7 @@
 class Comment : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(int, id)
     QM_PROPERTY(QString, comment)

--- a/comments.h
+++ b/comments.h
@@ -5,7 +5,7 @@
 class Comments : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(QList<Comment *>, comments)
     QM_PROPERTY(QString, nextUrl)

--- a/illusts.h
+++ b/illusts.h
@@ -51,7 +51,7 @@ class Recommended : public Illusts
 class SearchResults : public Illusts
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(bool, showAi)
 

--- a/piqi.h
+++ b/piqi.h
@@ -21,7 +21,7 @@
 class Piqi : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(Account *, user)
     QM_PROPERTY(QList<Account*>, otherUsers)

--- a/searchrequest.h
+++ b/searchrequest.h
@@ -12,7 +12,7 @@
 class SearchRequest : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     public:
         enum class SearchTarget {

--- a/stamp.h
+++ b/stamp.h
@@ -5,7 +5,7 @@
 
 class Stamp : public QObject {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(int, id)
     QM_PROPERTY(QString, url)

--- a/tag.h
+++ b/tag.h
@@ -6,7 +6,7 @@
 class Tag : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(QString, name)
     QM_PROPERTY(QString, translatedName)
@@ -19,7 +19,7 @@ class Tag : public QObject
 class BookmarkTag : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(QString, name)
     QM_PROPERTY(bool, isRegistered)

--- a/user.h
+++ b/user.h
@@ -5,7 +5,7 @@
 class User : public QObject
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(int, id)
     QM_PROPERTY(QString, name)
@@ -22,7 +22,7 @@ public:
 class Account : public User
 {
     Q_OBJECT
-    QML_ELEMENT;
+    QML_ELEMENT
 
     QM_PROPERTY(bool, isMailAuthorized)
     QM_PROPERTY(bool, isPremium)


### PR DESCRIPTION
This is unnecessary, and gets rid of the "warning: extra ';' inside a class" during compilation.