### PR TITLE
Make Illusts model-based

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ ecm_add_qml_module(piqi
         imageurls.cpp
         series.cpp
         tag.cpp
+        illusts.cpp
 
         piqi.cpp
 

--- a/illusts.cpp
+++ b/illusts.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Joshua Goins <josh@redstrate.com>
+
+#include "illusts.h"
+
+int Illusts::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return m_illusts.count();
+}
+
+QVariant Illusts::data(const QModelIndex &index, int role) const
+{
+    const auto illustration = m_illusts[index.row()];
+    if (role == CustomRoles::IllustRole) {
+        return QVariant::fromValue(illustration);
+    }
+    return {};
+}
+
+QHash<int, QByteArray> Illusts::roleNames() const
+{
+    return {
+        {CustomRoles::IllustRole, QByteArrayLiteral("illust")},
+    };
+}


### PR DESCRIPTION
Doing it the previous way (QML list property) is... fine but it should really be avoided. It creates bindings which are slow to update - especially for properties this big - and if we want to say, add more illustrations to the list then QML has to re-create the entire list which makes the application much slower.

The previous illusts API was not removed yet, so it will continue to function.